### PR TITLE
Expose registerParser method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var gutil = require('gulp-util'),
-	parse = require('aster-parse')(),
+	parse = require('aster-parse'),
 	sourceMapToAst = require('sourcemap-to-ast'),
 	generate = require('escodegen').generate,
 	Rx = require('rx'),
@@ -29,7 +29,7 @@ module.exports = function (asterTransform) {
 			}
 		});
 
-		files = parse(files).zip(observable.pluck('sourceMap'), function (file, sourceMap) {
+    files = parse()(files).zip(observable.pluck('sourceMap'), function (file, sourceMap) {
 			if (sourceMap) {
 				sourceMapToAst(file.program, sourceMap);
 			}
@@ -58,3 +58,5 @@ module.exports = function (asterTransform) {
 		return files;
 	});
 };
+
+module.exports.registerParser = parse.registerParser;


### PR DESCRIPTION
There is no way to use esnext parse in gulp-aster because of registerParser is not exposed.
